### PR TITLE
Updating Rinku to 1.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ koinBom = "4.0.0"
 kotlinxCollectionsImmutable = "0.3.7"
 kotlinxSerializationJson = "1.7.3"
 qrKit = "3.0.1"
-rink = "1.1.0"
+rinku = "1.3.0"
 napier = "2.7.1"
 konnectivity = "0.1-alpha01"
 crashkios = "0.8.6"
@@ -74,8 +74,8 @@ koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compos
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 qr-kit = { group = "network.chaintech", name = "qr-kit", version.ref = "qrKit" }
-rinku = { group = "dev.theolm", name = "rinku", version.ref = "rink" }
-rinku-compose-ext = { group = "dev.theolm", name = "rinku-compose-ext", version.ref = "rink" }
+rinku = { group = "dev.theolm", name = "rinku", version.ref = "rinku" }
+rinku-compose-ext = { group = "dev.theolm", name = "rinku-compose-ext", version.ref = "rinku" }
 aakira-napier = { group = "io.github.aakira", name = "napier", version.ref = "napier" }
 plusmobileapps-konnectivity = { group = "com.plusmobileapps", name = "konnectivity", version.ref = "konnectivity" }
 crashkios-crashlytics = { group = "co.touchlab.crashkios", name = "crashlytics", version.ref = "crashkios" }


### PR DESCRIPTION
This PR updates Rinku to the latest version and should address both problems that you pointed out.
Now you should be able to write your tests.